### PR TITLE
Standard proxy config gets now build into the sdk.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ def getSDKCopySpec() {
             from files(rootProject.external.moe_core.out.proguard_cfg.parentFile) {
                 include rootProject.external.moe_core.out.jni_config_base_json.name
                 include rootProject.external.moe_core.out.reflection_config_base_json.name
+                include rootProject.external.moe_core.out.proxy_config_base_json.name
                 include rootProject.external.moe_core.out.proguard_full_cfg.name
                 include rootProject.external.moe_core.out.proguard_cfg.name
             }


### PR DESCRIPTION
I had some trouble with building the sdk so I couldn't test well whether the file gets included or not but it should work.